### PR TITLE
fix: handle allowed protocols for services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 *.vsix
 .env
 .idea
+coverage

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -6,6 +6,8 @@ module.exports = {
     testMatch: [
         "<rootDir>/src/web/api-services/**/*.test.ts",
         "<rootDir>/src/web/api-services/**/*.test.tsx",
+        "<rootDir>/tests/**/*.test.ts",
+        "<rootDir>/tests/**/*.test.tsx",
     ],
 
     testPathIgnorePatterns: [
@@ -19,7 +21,7 @@ module.exports = {
             "ts-jest",
             {
                 tsconfig: "<rootDir>/tsconfig.json",
-                diagnostics: { ignoreCodes: [151002] },
+                diagnostics: { ignoreCodes: [151002, 1192, 7006] },
             },
         ],
     },
@@ -27,8 +29,12 @@ module.exports = {
     collectCoverage: true,
     collectCoverageFrom: [
         "<rootDir>/src/web/api-services/**/*.{ts,tsx}",
+        "<rootDir>/src/web/response/**/*.{ts,tsx}",
+        "<rootDir>/src/web/extension.ts",
         "!<rootDir>/src/web/api-services/**/*.d.ts",
         "!<rootDir>/src/web/api-services/**/*.{test,spec}.{ts,tsx}",
+        "!<rootDir>/src/web/response/**/*.d.ts",
+        "!<rootDir>/src/web/response/**/*.{test,spec}.{ts,tsx}",
     ],
     coverageDirectory: "coverage",
     coverageReporters: ["text", "lcov", "html"],

--- a/src/web/api-services/SpecificationImportService.ts
+++ b/src/web/api-services/SpecificationImportService.ts
@@ -31,6 +31,7 @@ import { normalizePath } from "./pathUtils";
 import type { EnvironmentRequest } from "./servicesTypes";
 import { EnvironmentDefaultProperties } from "./EnvironmentDefaultProperties";
 import { ProtocolDetectorService } from "../services/ProtocolDetectorService";
+import { validateAllowedSystemProtocol } from "../response";
 
 export class SpecificationImportService {
   private progressTracker: ImportProgressTracker;
@@ -160,7 +161,8 @@ export class SpecificationImportService {
         window.showErrorMessage(errorMessage);
         throw new Error(errorMessage);
       }
-
+      const systemType = params.system.integrationSystemType;
+      validateAllowedSystemProtocol(systemType, importingProtocol);
       const systemProtocol = this.convertToApiSpecificationType(
         params.system.protocol,
       );

--- a/src/web/api-services/SpecificationImportService.ts
+++ b/src/web/api-services/SpecificationImportService.ts
@@ -161,8 +161,10 @@ export class SpecificationImportService {
         window.showErrorMessage(errorMessage);
         throw new Error(errorMessage);
       }
-      const systemType = params.system.integrationSystemType;
-      validateAllowedSystemProtocol(systemType, importingProtocol);
+      validateAllowedSystemProtocol(
+        params.system.integrationSystemType,
+        importingProtocol,
+      );
       const systemProtocol = this.convertToApiSpecificationType(
         params.system.protocol,
       );

--- a/src/web/extension.ts
+++ b/src/web/extension.ts
@@ -12,10 +12,10 @@ import { getApiResponse } from "./response";
 import { setFileApi } from "./response/file";
 import { VSCodeFileApi } from "./response/file/fileApiImpl";
 import {
-    getExtensionsForUri,
-    setCurrentFileContext,
-    extractFilename,
-    initializeContextFromFile
+  getExtensionsForUri,
+  setCurrentFileContext,
+  extractFilename,
+  initializeContextFromFile,
 } from "./response/file/fileExtensions";
 import { QipExplorerProvider } from "./qipExplorer";
 import { VSCodeMessage, VSCodeResponse } from "@netcracker/qip-ui";
@@ -227,62 +227,68 @@ export function refreshQipExplorer() {
 class ChainFileEditorProvider implements CustomTextEditorProvider {
   constructor(private readonly context: ExtensionContext) {}
 
-    async resolveCustomTextEditor(
-        document: TextDocument,
-        panel: WebviewPanel,
-        _token: CancellationToken
-    ): Promise<void> {
-        if (!document || !document.uri || !panel || !this.context || !this.context.extensionUri) {
-            throw new Error("Invalid parameters for resolveCustomTextEditor");
-        }
+  async resolveCustomTextEditor(
+    document: TextDocument,
+    panel: WebviewPanel,
+    _token: CancellationToken,
+  ): Promise<void> {
+    if (
+      !document ||
+      !document.uri ||
+      !panel ||
+      !this.context ||
+      !this.context.extensionUri
+    ) {
+      throw new Error("Invalid parameters for resolveCustomTextEditor");
+    }
 
-        try {
-            const webview = panel.webview;
-            if (!webview) {
-                throw new Error("Panel.webview is required but was null or undefined");
-            }
+    try {
+      const webview = panel.webview;
+      if (!webview) {
+        throw new Error("Panel.webview is required but was null or undefined");
+      }
 
-            webview.options = {
-                localResourceRoots: [this.context.extensionUri],
-                enableScripts: true,
-                enableCommandUris: true
-            };
+      webview.options = {
+        localResourceRoots: [this.context.extensionUri],
+        enableScripts: true,
+        enableCommandUris: true,
+      };
 
-    panel.onDidChangeViewState(async (e) => {
-      if (e.webviewPanel.active) {
-        const path = await getAndClearNavigationStateValue(
-          this.context,
-          document.uri,
-        );
-
-        if (path) {
-          const navigateMessage: VSCodeMessage<any> = {
-            requestId: crypto.randomUUID(),
-            type: "navigate",
-            payload: { path: path },
-          };
-
-          const response: VSCodeResponse<any> = {
-            requestId: navigateMessage.requestId,
-            type: navigateMessage.type,
-          };
-
-          response.payload = await getApiResponse(
-            navigateMessage,
-            document.uri,
+      panel.onDidChangeViewState(async (e) => {
+        if (e.webviewPanel.active) {
+          const path = await getAndClearNavigationStateValue(
             this.context,
+            document.uri,
           );
 
-          panel.webview.postMessage(response);
-        }
-      }
-    });
+          if (path) {
+            const navigateMessage: VSCodeMessage<any> = {
+              requestId: crypto.randomUUID(),
+              type: "navigate",
+              payload: { path: path },
+            };
 
-            await enrichWebview(panel, this.context, document.uri);
-        } catch (error) {
-            throw error;
+            const response: VSCodeResponse<any> = {
+              requestId: navigateMessage.requestId,
+              type: navigateMessage.type,
+            };
+
+            response.payload = await getApiResponse(
+              navigateMessage,
+              document.uri,
+              this.context,
+            );
+
+            panel.webview.postMessage(response);
+          }
         }
+      });
+
+      await enrichWebview(panel, this.context, document.uri);
+    } catch (error) {
+      throw error;
     }
+  }
 }
 
 function openWebviewForElement(
@@ -305,15 +311,19 @@ function openWebviewForElement(
   enrichWebview(panel, context, fileUri);
 }
 
-async function enrichWebview(panel: WebviewPanel, context: ExtensionContext, fileUri: Uri | undefined = undefined) {
-    if (!panel || !context || !context.extensionUri || !panel.webview) {
-        throw new Error("Invalid parameters for enrichWebview");
-    }
+async function enrichWebview(
+  panel: WebviewPanel,
+  context: ExtensionContext,
+  fileUri: Uri | undefined = undefined,
+) {
+  if (!panel || !context || !context.extensionUri || !panel.webview) {
+    throw new Error("Invalid parameters for enrichWebview");
+  }
 
-    type VSCodeMessageWrapper = {
-        command: string;
-        data: VSCodeMessage<any>;
-    };
+  type VSCodeMessageWrapper = {
+    command: string;
+    data: VSCodeMessage<any>;
+  };
 
   if (fileUri) {
     try {
@@ -386,7 +396,7 @@ async function enrichWebview(panel: WebviewPanel, context: ExtensionContext, fil
     } catch (e) {
       console.error("Failed to fetch data for QIP Extension API", e);
       if (e instanceof Error) {
-        response.error = e;
+        response.error = { message: e.message, name: e.name };
       }
     }
     panel.webview.postMessage(response);
@@ -812,65 +822,67 @@ export function activate(context: ExtensionContext): QipExtensionAPI {
 export function deactivate() {}
 
 async function getWebviewContent(context: ExtensionContext, webview: Webview) {
-    if (!context || !context.extensionUri || !webview) {
-        throw new Error("Invalid parameters for getWebviewContent");
-    }
+  if (!context || !context.extensionUri || !webview) {
+    throw new Error("Invalid parameters for getWebviewContent");
+  }
 
-    // Dynamically load the JS and CSS files
-    // Use bundled version for VSCode extension (includes React)
-    let jsUri: vscode.Uri;
-    let cssUri: vscode.Uri;
-    let useBundled = false; // Will be set based on file existence
+  // Dynamically load the JS and CSS files
+  // Use bundled version for VSCode extension (includes React)
+  let jsUri: vscode.Uri;
+  let cssUri: vscode.Uri;
+  let useBundled = false; // Will be set based on file existence
 
+  try {
+    // Try bundled version first (includes React)
+    let jsFileUri = vscode.Uri.joinPath(
+      context.extensionUri,
+      "node_modules",
+      "@netcracker",
+      "qip-ui",
+      "dist-lib",
+      "index.bundled.es.js",
+    );
+
+    // Check if bundled version exists using VSCode API (works in web extensions)
+    // Try to stat the bundled file - if it fails, use external version
+    let bundledExists = false;
     try {
-        // Try bundled version first (includes React)
-        let jsFileUri = vscode.Uri.joinPath(
-            context.extensionUri,
-            'node_modules',
-            '@netcracker',
-            'qip-ui',
-            'dist-lib',
-            'index.bundled.es.js'
-        );
-
-        // Check if bundled version exists using VSCode API (works in web extensions)
-        // Try to stat the bundled file - if it fails, use external version
-        let bundledExists = false;
-        try {
-            await vscode.workspace.fs.stat(jsFileUri);
-            bundledExists = true;
-        } catch (error) {
-            jsFileUri = vscode.Uri.joinPath(
-                context.extensionUri,
-                'node_modules',
-                '@netcracker',
-                'qip-ui',
-                'dist-lib',
-                'index.es.js'
-            );
-        }
-
-        useBundled = bundledExists;
-        const cssFileUri = vscode.Uri.joinPath(
-            context.extensionUri,
-            'node_modules',
-            '@netcracker',
-            'qip-ui',
-            'dist-lib',
-            'qip-ui.css'
-        );
-
-        jsUri = webview.asWebviewUri(jsFileUri);
-        cssUri = webview.asWebviewUri(cssFileUri);
-
-        if (!jsUri || !cssUri) {
-            throw new Error("Failed to convert file URIs to webview URIs");
-        }
+      await vscode.workspace.fs.stat(jsFileUri);
+      bundledExists = true;
     } catch (error) {
-        throw error;
+      jsFileUri = vscode.Uri.joinPath(
+        context.extensionUri,
+        "node_modules",
+        "@netcracker",
+        "qip-ui",
+        "dist-lib",
+        "index.es.js",
+      );
     }
 
-    const importMapScript = useBundled ? '' : `
+    useBundled = bundledExists;
+    const cssFileUri = vscode.Uri.joinPath(
+      context.extensionUri,
+      "node_modules",
+      "@netcracker",
+      "qip-ui",
+      "dist-lib",
+      "qip-ui.css",
+    );
+
+    jsUri = webview.asWebviewUri(jsFileUri);
+    cssUri = webview.asWebviewUri(cssFileUri);
+
+    if (!jsUri || !cssUri) {
+      throw new Error("Failed to convert file URIs to webview URIs");
+    }
+  } catch (error) {
+    throw error;
+  }
+
+  const importMapScript = useBundled
+    ? ""
+    : `
         <script type="importmap">
         {
           "imports": {
@@ -882,7 +894,7 @@ async function getWebviewContent(context: ExtensionContext, webview: Webview) {
         </script>
     `;
 
-    const html = `
+  const html = `
     <!DOCTYPE html>
     <html lang="en">
       <head>
@@ -920,5 +932,5 @@ async function getWebviewContent(context: ExtensionContext, webview: Webview) {
       </body>
     </html>
   `;
-    return html;
+  return html;
 }

--- a/src/web/extension.ts
+++ b/src/web/extension.ts
@@ -903,7 +903,7 @@ async function getWebviewContent(context: ExtensionContext, webview: Webview) {
         <title>QIP Offline Chain Editor</title>
         <link href="${cssUri}" rel="stylesheet">
         ${importMapScript}
-	    <script type="module" crossorigin src="${jsUri}"></script>
+        <script type="module" crossorigin src="${jsUri}"></script>
         <style>
           html, body {
             margin: 0 !important;

--- a/src/web/extension.ts
+++ b/src/web/extension.ts
@@ -232,13 +232,7 @@ class ChainFileEditorProvider implements CustomTextEditorProvider {
     panel: WebviewPanel,
     _token: CancellationToken,
   ): Promise<void> {
-    if (
-      !document ||
-      !document.uri ||
-      !panel ||
-      !this.context ||
-      !this.context.extensionUri
-    ) {
+    if (!document?.uri || !panel || !this.context?.extensionUri) {
       throw new Error("Invalid parameters for resolveCustomTextEditor");
     }
 

--- a/src/web/response/serviceApiModify.ts
+++ b/src/web/response/serviceApiModify.ts
@@ -21,6 +21,7 @@ import { refreshQipExplorer } from "../extension";
 import { LabelUtils } from "../api-services/LabelUtils";
 import { ProjectConfigService } from "../services/ProjectConfigService";
 import { ContextSystem } from "@netcracker/qip-ui";
+import { validateAllowedSystemProtocol } from "./serviceApiUtils";
 
 export async function updateContextService(
   serviceFileUri: Uri,
@@ -78,6 +79,10 @@ export async function updateService(
       serviceRequest.integrationSystemType;
   }
   if (serviceRequest.type !== undefined) {
+    validateAllowedSystemProtocol(
+      serviceRequest.type,
+      service.content.protocol,
+    );
     service.content.integrationSystemType = serviceRequest.type;
   }
   if (serviceRequest.protocol !== undefined) {

--- a/src/web/response/serviceApiUtils.ts
+++ b/src/web/response/serviceApiUtils.ts
@@ -3,7 +3,11 @@ import { fileApi } from "./file/fileApiProvider";
 import { getCurrentServiceId } from "./serviceApiRead";
 import { createService } from "./serviceApiModify";
 import { SpecificationImportApiHandler } from "../api-services/SpecificationImportApiHandler";
-import { SerializedFile } from "../api-services/importApiTypes";
+import {
+  ApiSpecificationType,
+  SerializedFile,
+} from "../api-services/importApiTypes";
+import { IntegrationSystemType } from "../api-services/servicesTypes";
 
 export async function getContextServiceUri(
   serviceFileUri: vscode.Uri,
@@ -204,5 +208,42 @@ export async function handleReadSpecificationFileContent(
       }
     }
     throw error;
+  }
+}
+
+export const ALLOWED_PROTOCOL_MAP: ReadonlyMap<
+  IntegrationSystemType,
+  ReadonlySet<ApiSpecificationType>
+> = new Map([
+  [
+    IntegrationSystemType.EXTERNAL,
+    new Set(Object.values(ApiSpecificationType)),
+  ],
+  [
+    IntegrationSystemType.INTERNAL,
+    new Set(Object.values(ApiSpecificationType)),
+  ],
+  [
+    IntegrationSystemType.IMPLEMENTED,
+    new Set([
+      ApiSpecificationType.HTTP,
+      ApiSpecificationType.SOAP,
+      ApiSpecificationType.GRAPHQL,
+    ]),
+  ],
+]);
+
+export function validateAllowedSystemProtocol(
+  systemType?: IntegrationSystemType,
+  protocol?: ApiSpecificationType,
+) {
+  if (!systemType || !protocol) {
+    return;
+  }
+
+  const allowedProtocols = ALLOWED_PROTOCOL_MAP.get(systemType);
+  if (allowedProtocols && !allowedProtocols.has(protocol)) {
+    const errorMessage = `Specification type is not allowed for ${systemType.toLowerCase()} system: ${protocol}`;
+    throw new Error(errorMessage);
   }
 }

--- a/tests/api-services/SpecificationImportService.test.ts
+++ b/tests/api-services/SpecificationImportService.test.ts
@@ -1,0 +1,144 @@
+import {
+  createVscodeMock,
+  stubFileApi,
+  stubLabelUtils,
+  stubProjectConfigService,
+  buildSystem,
+  buildSerializedOpenApiFile,
+} from "../helpers/mocks";
+
+
+const mockValidateAllowedSystemProtocol = jest.fn();
+const mockGetSystemById = jest.fn();
+const mockCreateSpecificationGroup = jest.fn();
+const mockSaveSpecificationGroupFile = jest.fn();
+const mockGetSpecificationGroupById = jest.fn();
+const mockFailImportSession = jest.fn();
+
+
+jest.mock("vscode", () => createVscodeMock(), { virtual: true });
+jest.mock("yaml", () => ({ stringify: jest.fn().mockReturnValue(""), parse: jest.fn() }));
+jest.mock("../../src/web/response", () => ({
+  validateAllowedSystemProtocol: mockValidateAllowedSystemProtocol,
+}));
+jest.mock("../../src/web/response/file/fileApiProvider", () =>
+  stubFileApi({ getFileType: jest.fn().mockResolvedValue("SERVICE") }),
+);
+jest.mock("../../src/web/api-services/LabelUtils", () => stubLabelUtils());
+jest.mock("../../src/web/services/ProjectConfigService", () => stubProjectConfigService());
+
+jest.mock("../../src/web/api-services/SystemService", () => ({
+  SystemService: jest.fn().mockImplementation(() => ({
+    getSystemById: mockGetSystemById,
+    saveSystem: jest.fn(),
+  })),
+}));
+jest.mock("../../src/web/api-services/SpecificationGroupService", () => ({
+  SpecificationGroupService: jest.fn().mockImplementation(() => ({
+    createSpecificationGroup: mockCreateSpecificationGroup,
+    saveSpecificationGroupFile: mockSaveSpecificationGroupFile,
+    getSpecificationGroupById: mockGetSpecificationGroupById,
+  })),
+}));
+jest.mock("../../src/web/api-services/SpecificationProcessorService", () => ({
+  SpecificationProcessorService: jest.fn().mockImplementation(() => ({
+    processSpecificationFiles: jest.fn(),
+    extractEnvironmentCandidates: jest.fn().mockReturnValue([]),
+  })),
+}));
+jest.mock("../../src/web/api-services/EnvironmentService", () => ({
+  EnvironmentService: jest.fn().mockImplementation(() => ({
+    getEnvironmentsForSystem: jest.fn().mockResolvedValue([]),
+    createEnvironment: jest.fn(),
+    updateEnvironment: jest.fn(),
+  })),
+}));
+jest.mock("../../src/web/api-services/importProgressTracker", () => ({
+  ImportProgressTracker: {
+    getInstance: jest.fn().mockReturnValue({
+      startImportSession: jest.fn(),
+      completeImportSession: jest.fn(),
+      failImportSession: mockFailImportSession,
+      getImportSession: jest.fn(),
+    }),
+  },
+}));
+jest.mock("../../src/web/api-services/parsers/SoapSpecificationParser", () => ({
+  SoapSpecificationParser: { parseWsdlContent: jest.fn() },
+}));
+jest.mock("../../src/web/api-services/parsers/ContentParser", () => ({
+  ContentParser: { parseContent: jest.fn(), parseContentFromFile: jest.fn() },
+}));
+jest.mock("../../src/web/api-services/SpecificationValidator", () => ({
+  SpecificationValidator: { validateSpecificationProtocol: jest.fn() },
+}));
+jest.mock("../../src/web/api-services/pathUtils", () => ({
+  normalizePath: jest.fn((p: string) => p),
+}));
+jest.mock("../../src/web/api-services/EnvironmentDefaultProperties", () => ({
+  EnvironmentDefaultProperties: { getDefaultProperties: jest.fn().mockReturnValue({}) },
+}));
+jest.mock("../../src/web/services/ProtocolDetectorService", () => ({
+  ProtocolDetectorService: {
+    extractArchives: jest.fn((files: File[]) => Promise.resolve(files)),
+  },
+}));
+
+
+import { SpecificationImportService } from "../../src/web/api-services/SpecificationImportService";
+import { IntegrationSystemType } from "../../src/web/api-services/servicesTypes";
+
+
+describe("SpecificationImportService – validateAllowedSystemProtocol in runImport", () => {
+  let service: SpecificationImportService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new SpecificationImportService({ path: "/fake/service.yaml" } as any);
+  });
+
+  test("calls validateAllowedSystemProtocol with system type and detected protocol", async () => {
+    mockGetSystemById.mockResolvedValue(
+      buildSystem({ integrationSystemType: IntegrationSystemType.IMPLEMENTED }),
+    );
+    mockCreateSpecificationGroup.mockResolvedValue({
+      id: "grp-1",
+      name: "Test Group",
+      specifications: [],
+      synchronization: false,
+    });
+
+    await service.importSpecificationGroup({
+      systemId: "sys-1",
+      name: "Test Group",
+      files: [buildSerializedOpenApiFile()],
+    });
+
+    expect(mockValidateAllowedSystemProtocol).toHaveBeenCalledWith(
+      IntegrationSystemType.IMPLEMENTED,
+      expect.any(String),
+    );
+  });
+
+  test("returns warningMessage (graceful failure) when validation throws", async () => {
+    mockGetSystemById.mockResolvedValue(
+      buildSystem({
+        integrationSystemType: IntegrationSystemType.IMPLEMENTED,
+        protocol: "GRPC",
+      }),
+    );
+    mockValidateAllowedSystemProtocol.mockImplementation(() => {
+      throw new Error("Specification type is not allowed for implemented system: HTTP");
+    });
+
+    const result = await service.importSpecificationGroup({
+      systemId: "sys-1",
+      name: "Test Group",
+      files: [buildSerializedOpenApiFile()],
+    });
+
+    expect(result.done).toBe(true);
+    expect(result.warningMessage).toBeDefined();
+    expect(mockFailImportSession).toHaveBeenCalled();
+  });
+});

--- a/tests/api-services/SpecificationImportService.test.ts
+++ b/tests/api-services/SpecificationImportService.test.ts
@@ -7,7 +7,6 @@ import {
   buildSerializedOpenApiFile,
 } from "../helpers/mocks";
 
-
 const mockValidateAllowedSystemProtocol = jest.fn();
 const mockGetSystemById = jest.fn();
 const mockCreateSpecificationGroup = jest.fn();
@@ -15,9 +14,11 @@ const mockSaveSpecificationGroupFile = jest.fn();
 const mockGetSpecificationGroupById = jest.fn();
 const mockFailImportSession = jest.fn();
 
-
 jest.mock("vscode", () => createVscodeMock(), { virtual: true });
-jest.mock("yaml", () => ({ stringify: jest.fn().mockReturnValue(""), parse: jest.fn() }));
+jest.mock("yaml", () => ({
+  stringify: jest.fn().mockReturnValue(""),
+  parse: jest.fn(),
+}));
 jest.mock("../../src/web/response", () => ({
   validateAllowedSystemProtocol: mockValidateAllowedSystemProtocol,
 }));
@@ -25,7 +26,9 @@ jest.mock("../../src/web/response/file/fileApiProvider", () =>
   stubFileApi({ getFileType: jest.fn().mockResolvedValue("SERVICE") }),
 );
 jest.mock("../../src/web/api-services/LabelUtils", () => stubLabelUtils());
-jest.mock("../../src/web/services/ProjectConfigService", () => stubProjectConfigService());
+jest.mock("../../src/web/services/ProjectConfigService", () =>
+  stubProjectConfigService(),
+);
 
 jest.mock("../../src/web/api-services/SystemService", () => ({
   SystemService: jest.fn().mockImplementation(() => ({
@@ -76,7 +79,9 @@ jest.mock("../../src/web/api-services/pathUtils", () => ({
   normalizePath: jest.fn((p: string) => p),
 }));
 jest.mock("../../src/web/api-services/EnvironmentDefaultProperties", () => ({
-  EnvironmentDefaultProperties: { getDefaultProperties: jest.fn().mockReturnValue({}) },
+  EnvironmentDefaultProperties: {
+    getDefaultProperties: jest.fn().mockReturnValue({}),
+  },
 }));
 jest.mock("../../src/web/services/ProtocolDetectorService", () => ({
   ProtocolDetectorService: {
@@ -84,17 +89,17 @@ jest.mock("../../src/web/services/ProtocolDetectorService", () => ({
   },
 }));
 
-
 import { SpecificationImportService } from "../../src/web/api-services/SpecificationImportService";
 import { IntegrationSystemType } from "../../src/web/api-services/servicesTypes";
-
 
 describe("SpecificationImportService – validateAllowedSystemProtocol in runImport", () => {
   let service: SpecificationImportService;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    service = new SpecificationImportService({ path: "/fake/service.yaml" } as any);
+    service = new SpecificationImportService({
+      path: "/fake/service.yaml",
+    } as any);
   });
 
   test("calls validateAllowedSystemProtocol with system type and detected protocol", async () => {
@@ -128,7 +133,9 @@ describe("SpecificationImportService – validateAllowedSystemProtocol in runImp
       }),
     );
     mockValidateAllowedSystemProtocol.mockImplementation(() => {
-      throw new Error("Specification type is not allowed for implemented system: HTTP");
+      throw new Error(
+        "Specification type is not allowed for implemented system: HTTP",
+      );
     });
 
     const result = await service.importSpecificationGroup({

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -1,0 +1,218 @@
+import {
+  createVscodeMock,
+  stubLabelUtils,
+  stubProjectConfigService,
+  buildMockContext,
+} from "./helpers/mocks";
+
+
+let capturedEditorProviders: Record<string, any> = {};
+let onDidReceiveMessageCallback: Function | null = null;
+let mockStatBehavior: "resolve" | "reject" = "resolve";
+
+const mockPostMessage = jest.fn();
+const mockWebview = {
+  options: {} as any,
+  html: "",
+  postMessage: mockPostMessage,
+  asWebviewUri: jest.fn((uri: any) => uri),
+  onDidReceiveMessage: jest.fn((cb: Function) => {
+    onDidReceiveMessageCallback = cb;
+    return { dispose: jest.fn() };
+  }),
+};
+const mockPanel = {
+  webview: mockWebview,
+  onDidChangeViewState: jest.fn(() => ({ dispose: jest.fn() })),
+  onDidDispose: jest.fn(() => ({ dispose: jest.fn() })),
+};
+
+
+jest.mock("vscode", () => {
+  const base = createVscodeMock();
+  return {
+    ...base,
+    window: {
+      ...base.window,
+      registerCustomEditorProvider: jest.fn((id: string, provider: any) => {
+        capturedEditorProviders[id] = provider;
+        return { dispose: jest.fn() };
+      }),
+      createWebviewPanel: jest.fn(() => mockPanel),
+    },
+    commands: {
+      registerCommand: jest.fn(() => ({ dispose: jest.fn() })),
+      executeCommand: jest.fn(),
+    },
+    workspace: {
+      ...base.workspace,
+      fs: {
+        ...base.workspace.fs,
+        stat: jest.fn(() =>
+          mockStatBehavior === "resolve"
+            ? Promise.resolve({ type: 1 })
+            : Promise.reject(new Error("File not found")),
+        ),
+      },
+    },
+  };
+}, { virtual: true });
+
+const mockGetApiResponse = jest.fn();
+
+jest.mock("../src/web/response", () => ({ getApiResponse: mockGetApiResponse }));
+jest.mock("../src/web/response/file", () => ({ setFileApi: jest.fn() }));
+jest.mock("../src/web/response/file/fileApiImpl", () => ({
+  VSCodeFileApi: jest.fn().mockImplementation(() => ({
+    createEmptyChain: jest.fn(),
+    createEmptyService: jest.fn(),
+    createEmptyContextService: jest.fn(),
+  })),
+}));
+jest.mock("../src/web/response/file/fileExtensions", () => ({
+  getExtensionsForUri: jest.fn().mockReturnValue({
+    chain: ".qip-chain.yaml",
+    service: ".qip-service.yaml",
+    contextService: ".qip-context-service.yaml",
+    specificationGroup: ".qip-sg.yaml",
+    specification: ".qip-spec.yaml",
+  }),
+  getExtensionsForFile: jest.fn().mockReturnValue({
+    chain: ".qip-chain.yaml",
+    service: ".qip-service.yaml",
+  }),
+  setCurrentFileContext: jest.fn(),
+  extractFilename: jest.fn(),
+  initializeContextFromFile: jest.fn(),
+}));
+jest.mock("../src/web/qipExplorer", () => ({
+  QipExplorerProvider: jest.fn().mockImplementation(() => ({
+    refresh: jest.fn(),
+    getTreeItem: jest.fn(),
+    getChildren: jest.fn(),
+  })),
+}));
+jest.mock("@netcracker/qip-ui", () => ({}), { virtual: true });
+jest.mock("../src/web/services/FileCacheService", () => ({
+  FileCacheService: { getInstance: jest.fn().mockReturnValue({ invalidateByUri: jest.fn() }) },
+}));
+jest.mock("../src/web/services/ProjectConfigService", () => stubProjectConfigService());
+jest.mock("../src/web/services/ConfigApiProvider", () => ({
+  ConfigApiProvider: { getInstance: jest.fn().mockReturnValue({}) },
+}));
+jest.mock("../src/web/response/navigationUtils", () => ({
+  getAndClearNavigationStateValue: jest.fn(),
+  getNavigationStateValue: jest.fn(),
+  initNavigationState: jest.fn(),
+  updateNavigationStateValue: jest.fn(),
+}));
+
+
+import { activate } from "../src/web/extension";
+
+function activateAndGetProvider() {
+  activate(buildMockContext());
+  return capturedEditorProviders["qip.chainFile.editor"];
+}
+
+const validDocument = { uri: { path: "/test.yaml", fsPath: "/test.yaml" } };
+
+async function openEditorAndGetMessageHandler() {
+  const provider = activateAndGetProvider();
+  await provider.resolveCustomTextEditor(validDocument as any, mockPanel as any, {} as any);
+  return onDidReceiveMessageCallback!;
+}
+
+
+describe("extension.ts", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedEditorProviders = {};
+    onDidReceiveMessageCallback = null;
+    mockStatBehavior = "resolve";
+    mockWebview.html = "";
+  });
+
+
+  describe("resolveCustomTextEditor – rejects invalid parameters", () => {
+    let provider: any;
+    beforeEach(() => { provider = activateAndGetProvider(); });
+
+    test("throws when document.uri is falsy", async () => {
+      await expect(
+        provider.resolveCustomTextEditor({ uri: null } as any, mockPanel as any, {} as any),
+      ).rejects.toThrow("Invalid parameters for resolveCustomTextEditor");
+    });
+
+    test("throws when panel is null", async () => {
+      await expect(
+        provider.resolveCustomTextEditor(validDocument as any, null as any, {} as any),
+      ).rejects.toThrow("Invalid parameters for resolveCustomTextEditor");
+    });
+  });
+
+
+  describe("enrichWebview – onDidReceiveMessage error handling", () => {
+    let handleMessage: Function;
+
+    beforeEach(async () => {
+      handleMessage = await openEditorAndGetMessageHandler();
+    });
+
+    test("populates response.error when getApiResponse throws an Error", async () => {
+      const testError = new Error("Something went wrong");
+      testError.name = "TestError";
+      mockGetApiResponse.mockRejectedValue(testError);
+
+      await handleMessage({
+        command: "apiCall",
+        data: { requestId: "req-1", type: "getChain", payload: {} },
+      });
+
+      expect(mockPostMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          requestId: "req-1",
+          type: "getChain",
+          error: { message: "Something went wrong", name: "TestError" },
+        }),
+      );
+    });
+
+    test("does not set response.error for non-Error throws", async () => {
+      mockGetApiResponse.mockRejectedValue("string error");
+
+      await handleMessage({
+        command: "apiCall",
+        data: { requestId: "req-2", type: "getChain", payload: {} },
+      });
+
+      const calls = mockPostMessage.mock.calls;
+      const posted = calls[calls.length - 1][0];
+      expect(posted.requestId).toBe("req-2");
+      expect(posted.error).toBeUndefined();
+    });
+  });
+
+
+  describe("getWebviewContent – importMapScript", () => {
+    test("omits importmap when bundled JS file exists", async () => {
+      mockStatBehavior = "resolve";
+      const provider = activateAndGetProvider();
+
+      await provider.resolveCustomTextEditor(validDocument as any, mockPanel as any, {} as any);
+
+      expect(mockWebview.html).toContain("<!DOCTYPE html>");
+      expect(mockWebview.html).not.toContain("importmap");
+    });
+
+    test("includes React importmap when bundled JS file is missing", async () => {
+      mockStatBehavior = "reject";
+      const provider = activateAndGetProvider();
+
+      await provider.resolveCustomTextEditor(validDocument as any, mockPanel as any, {} as any);
+
+      expect(mockWebview.html).toContain("importmap");
+      expect(mockWebview.html).toContain("esm.sh/react@18.3.1");
+    });
+  });
+});

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -1,10 +1,8 @@
 import {
   createVscodeMock,
-  stubLabelUtils,
   stubProjectConfigService,
   buildMockContext,
 } from "./helpers/mocks";
-
 
 let capturedEditorProviders: Record<string, any> = {};
 let onDidReceiveMessageCallback: Function | null = null;
@@ -27,40 +25,45 @@ const mockPanel = {
   onDidDispose: jest.fn(() => ({ dispose: jest.fn() })),
 };
 
-
-jest.mock("vscode", () => {
-  const base = createVscodeMock();
-  return {
-    ...base,
-    window: {
-      ...base.window,
-      registerCustomEditorProvider: jest.fn((id: string, provider: any) => {
-        capturedEditorProviders[id] = provider;
-        return { dispose: jest.fn() };
-      }),
-      createWebviewPanel: jest.fn(() => mockPanel),
-    },
-    commands: {
-      registerCommand: jest.fn(() => ({ dispose: jest.fn() })),
-      executeCommand: jest.fn(),
-    },
-    workspace: {
-      ...base.workspace,
-      fs: {
-        ...base.workspace.fs,
-        stat: jest.fn(() =>
-          mockStatBehavior === "resolve"
-            ? Promise.resolve({ type: 1 })
-            : Promise.reject(new Error("File not found")),
-        ),
+jest.mock(
+  "vscode",
+  () => {
+    const base = createVscodeMock();
+    return {
+      ...base,
+      window: {
+        ...base.window,
+        registerCustomEditorProvider: jest.fn((id: string, provider: any) => {
+          capturedEditorProviders[id] = provider;
+          return { dispose: jest.fn() };
+        }),
+        createWebviewPanel: jest.fn(() => mockPanel),
       },
-    },
-  };
-}, { virtual: true });
+      commands: {
+        registerCommand: jest.fn(() => ({ dispose: jest.fn() })),
+        executeCommand: jest.fn(),
+      },
+      workspace: {
+        ...base.workspace,
+        fs: {
+          ...base.workspace.fs,
+          stat: jest.fn(() =>
+            mockStatBehavior === "resolve"
+              ? Promise.resolve({ type: 1 })
+              : Promise.reject(new Error("File not found")),
+          ),
+        },
+      },
+    };
+  },
+  { virtual: true },
+);
 
 const mockGetApiResponse = jest.fn();
 
-jest.mock("../src/web/response", () => ({ getApiResponse: mockGetApiResponse }));
+jest.mock("../src/web/response", () => ({
+  getApiResponse: mockGetApiResponse,
+}));
 jest.mock("../src/web/response/file", () => ({ setFileApi: jest.fn() }));
 jest.mock("../src/web/response/file/fileApiImpl", () => ({
   VSCodeFileApi: jest.fn().mockImplementation(() => ({
@@ -94,9 +97,13 @@ jest.mock("../src/web/qipExplorer", () => ({
 }));
 jest.mock("@netcracker/qip-ui", () => ({}), { virtual: true });
 jest.mock("../src/web/services/FileCacheService", () => ({
-  FileCacheService: { getInstance: jest.fn().mockReturnValue({ invalidateByUri: jest.fn() }) },
+  FileCacheService: {
+    getInstance: jest.fn().mockReturnValue({ invalidateByUri: jest.fn() }),
+  },
 }));
-jest.mock("../src/web/services/ProjectConfigService", () => stubProjectConfigService());
+jest.mock("../src/web/services/ProjectConfigService", () =>
+  stubProjectConfigService(),
+);
 jest.mock("../src/web/services/ConfigApiProvider", () => ({
   ConfigApiProvider: { getInstance: jest.fn().mockReturnValue({}) },
 }));
@@ -106,7 +113,6 @@ jest.mock("../src/web/response/navigationUtils", () => ({
   initNavigationState: jest.fn(),
   updateNavigationStateValue: jest.fn(),
 }));
-
 
 import { activate } from "../src/web/extension";
 
@@ -119,10 +125,13 @@ const validDocument = { uri: { path: "/test.yaml", fsPath: "/test.yaml" } };
 
 async function openEditorAndGetMessageHandler() {
   const provider = activateAndGetProvider();
-  await provider.resolveCustomTextEditor(validDocument as any, mockPanel as any, {} as any);
+  await provider.resolveCustomTextEditor(
+    validDocument as any,
+    mockPanel as any,
+    {} as any,
+  );
   return onDidReceiveMessageCallback!;
 }
-
 
 describe("extension.ts", () => {
   beforeEach(() => {
@@ -133,26 +142,34 @@ describe("extension.ts", () => {
     mockWebview.html = "";
   });
 
-
-  describe("resolveCustomTextEditor – rejects invalid parameters", () => {
+  describe("resolveCustomTextEditor - rejects invalid parameters", () => {
     let provider: any;
-    beforeEach(() => { provider = activateAndGetProvider(); });
+    beforeEach(() => {
+      provider = activateAndGetProvider();
+    });
 
     test("throws when document.uri is falsy", async () => {
       await expect(
-        provider.resolveCustomTextEditor({ uri: null } as any, mockPanel as any, {} as any),
+        provider.resolveCustomTextEditor(
+          { uri: null } as any,
+          mockPanel as any,
+          {} as any,
+        ),
       ).rejects.toThrow("Invalid parameters for resolveCustomTextEditor");
     });
 
     test("throws when panel is null", async () => {
       await expect(
-        provider.resolveCustomTextEditor(validDocument as any, null as any, {} as any),
+        provider.resolveCustomTextEditor(
+          validDocument as any,
+          null as any,
+          {} as any,
+        ),
       ).rejects.toThrow("Invalid parameters for resolveCustomTextEditor");
     });
   });
 
-
-  describe("enrichWebview – onDidReceiveMessage error handling", () => {
+  describe("enrichWebview - onDidReceiveMessage error handling", () => {
     let handleMessage: Function;
 
     beforeEach(async () => {
@@ -193,13 +210,16 @@ describe("extension.ts", () => {
     });
   });
 
-
-  describe("getWebviewContent – importMapScript", () => {
+  describe("getWebviewContent - importMapScript", () => {
     test("omits importmap when bundled JS file exists", async () => {
       mockStatBehavior = "resolve";
       const provider = activateAndGetProvider();
 
-      await provider.resolveCustomTextEditor(validDocument as any, mockPanel as any, {} as any);
+      await provider.resolveCustomTextEditor(
+        validDocument as any,
+        mockPanel as any,
+        {} as any,
+      );
 
       expect(mockWebview.html).toContain("<!DOCTYPE html>");
       expect(mockWebview.html).not.toContain("importmap");
@@ -209,7 +229,11 @@ describe("extension.ts", () => {
       mockStatBehavior = "reject";
       const provider = activateAndGetProvider();
 
-      await provider.resolveCustomTextEditor(validDocument as any, mockPanel as any, {} as any);
+      await provider.resolveCustomTextEditor(
+        validDocument as any,
+        mockPanel as any,
+        {} as any,
+      );
 
       expect(mockWebview.html).toContain("importmap");
       expect(mockWebview.html).toContain("esm.sh/react@18.3.1");

--- a/tests/helpers/mocks.ts
+++ b/tests/helpers/mocks.ts
@@ -1,0 +1,154 @@
+/**
+ * Shared mock factories for vscode extension tests.
+ */
+
+export function createMinimalVscodeMock() {
+  return { Uri: class Uri {}, __esModule: true };
+}
+
+export function createVscodeMock(overrides: Record<string, any> = {}) {
+  return {
+    Uri: {
+      joinPath: jest.fn((_base: any, ...segments: string[]) => ({
+        path: segments.join("/"),
+        fsPath: segments.join("/"),
+        with: jest.fn().mockReturnThis(),
+      })),
+      parse: jest.fn((s: string) => ({ path: s, fsPath: s })),
+    },
+    window: {
+      showInformationMessage: jest.fn(),
+      showErrorMessage: jest.fn(),
+      showWarningMessage: jest.fn(),
+      showInputBox: jest.fn(),
+      showQuickPick: jest.fn(),
+      registerCustomEditorProvider: jest.fn(),
+      registerTreeDataProvider: jest.fn(() => ({ dispose: jest.fn() })),
+      createWebviewPanel: jest.fn(),
+      activeColorTheme: { kind: 2, label: "Dark+" },
+      onDidChangeActiveColorTheme: jest.fn(() => ({ dispose: jest.fn() })),
+    },
+    workspace: {
+      getConfiguration: jest.fn().mockReturnValue({
+        get: jest.fn((_key: string, defaultVal: any) => defaultVal),
+      }),
+      workspaceFolders: [{ uri: { path: "/workspace", fsPath: "/workspace" } }],
+      createFileSystemWatcher: jest.fn(() => ({
+        onDidChange: jest.fn(),
+        onDidDelete: jest.fn(),
+        onDidCreate: jest.fn(),
+        dispose: jest.fn(),
+      })),
+      onDidChangeConfiguration: jest.fn(() => ({ dispose: jest.fn() })),
+      fs: { stat: jest.fn(), readDirectory: jest.fn().mockResolvedValue([]), delete: jest.fn() },
+      openTextDocument: jest.fn(),
+    },
+    commands: {
+      registerCommand: jest.fn(() => ({ dispose: jest.fn() })),
+      executeCommand: jest.fn(),
+    },
+    ViewColumn: { One: 1 },
+    ColorThemeKind: { Light: 1, Dark: 2, HighContrast: 3, HighContrastLight: 4 },
+    FileType: { File: 1, Directory: 2 },
+    version: "1.90.0",
+    ...overrides,
+  };
+}
+
+
+export function stubFileApi(extra: Record<string, any> = {}) {
+  return {
+    fileApi: {
+      writeFile: jest.fn(),
+      writeMainService: jest.fn(),
+      writeServiceFile: jest.fn(),
+      getContextService: jest.fn(),
+      getSpecificationGroupFiles: jest.fn(),
+      getSpecificationFiles: jest.fn(),
+      deleteFile: jest.fn(),
+      getFileType: jest.fn(),
+      parseFile: jest.fn(),
+      readFileContent: jest.fn(),
+      getSpecApiFiles: jest.fn(),
+      ...extra,
+    },
+  };
+}
+
+export function stubLabelUtils() {
+  return {
+    LabelUtils: {
+      fromEntityLabels: jest.fn().mockReturnValue([]),
+      toEntityLabels: jest.fn().mockReturnValue([]),
+    },
+  };
+}
+
+export function stubProjectConfigService(configOverrides: Record<string, any> = {}) {
+  return {
+    ProjectConfigService: {
+      getConfig: jest.fn().mockReturnValue({
+        schemaUrls: { service: "", specification: "", specificationGroup: "" },
+        extensions: { service: ".qip-service.yaml", specification: ".spec.yaml" },
+        ...configOverrides,
+      }),
+      getInstance: jest.fn().mockReturnValue({
+        setContext: jest.fn(),
+        loadWorkspaceConfig: jest.fn().mockResolvedValue(undefined),
+        getAllConfigs: jest.fn().mockReturnValue([]),
+        buildDefaultConfig: jest.fn().mockReturnValue({
+          extensions: { chain: ".qip-chain.yaml", service: ".qip-service.yaml" },
+        }),
+      }),
+    },
+    CONFIG_FILENAME: "qip-config.yaml",
+  };
+}
+
+
+import type { IntegrationSystem } from "../../src/web/api-services/servicesTypes";
+import { IntegrationSystemType } from "../../src/web/api-services/servicesTypes";
+
+export function buildSystem(overrides: Partial<IntegrationSystem> = {}): IntegrationSystem {
+  return {
+    id: "sys-1",
+    name: "Test System",
+    activeEnvironmentId: "",
+    integrationSystemType: IntegrationSystemType.EXTERNAL,
+    protocol: "HTTP",
+    extendedProtocol: "",
+    specification: "",
+    labels: [],
+    ...overrides,
+  };
+}
+
+export function buildServiceRecord(id: string, contentOverrides: Record<string, any> = {}) {
+  return {
+    id,
+    content: { protocol: "HTTP", ...contentOverrides },
+  };
+}
+
+export function buildSerializedOpenApiFile(name = "spec.json") {
+  const content = JSON.stringify({
+    openapi: "3.0.0",
+    info: { title: "Test", version: "1.0" },
+    paths: {},
+  });
+  return {
+    name,
+    size: content.length,
+    type: "application/json",
+    lastModified: Date.now(),
+    content: new TextEncoder().encode(content).buffer,
+  };
+}
+
+export function buildMockContext() {
+  return {
+    extensionUri: { path: "/ext", fsPath: "/ext" },
+    extension: { packageJSON: { version: "1.0.0" } },
+    subscriptions: [],
+  } as any;
+}

--- a/tests/helpers/mocks.ts
+++ b/tests/helpers/mocks.ts
@@ -40,7 +40,11 @@ export function createVscodeMock(overrides: Record<string, any> = {}) {
         dispose: jest.fn(),
       })),
       onDidChangeConfiguration: jest.fn(() => ({ dispose: jest.fn() })),
-      fs: { stat: jest.fn(), readDirectory: jest.fn().mockResolvedValue([]), delete: jest.fn() },
+      fs: {
+        stat: jest.fn(),
+        readDirectory: jest.fn().mockResolvedValue([]),
+        delete: jest.fn(),
+      },
       openTextDocument: jest.fn(),
     },
     commands: {
@@ -48,13 +52,17 @@ export function createVscodeMock(overrides: Record<string, any> = {}) {
       executeCommand: jest.fn(),
     },
     ViewColumn: { One: 1 },
-    ColorThemeKind: { Light: 1, Dark: 2, HighContrast: 3, HighContrastLight: 4 },
+    ColorThemeKind: {
+      Light: 1,
+      Dark: 2,
+      HighContrast: 3,
+      HighContrastLight: 4,
+    },
     FileType: { File: 1, Directory: 2 },
     version: "1.90.0",
     ...overrides,
   };
 }
-
 
 export function stubFileApi(extra: Record<string, any> = {}) {
   return {
@@ -84,12 +92,17 @@ export function stubLabelUtils() {
   };
 }
 
-export function stubProjectConfigService(configOverrides: Record<string, any> = {}) {
+export function stubProjectConfigService(
+  configOverrides: Record<string, any> = {},
+) {
   return {
     ProjectConfigService: {
       getConfig: jest.fn().mockReturnValue({
         schemaUrls: { service: "", specification: "", specificationGroup: "" },
-        extensions: { service: ".qip-service.yaml", specification: ".spec.yaml" },
+        extensions: {
+          service: ".qip-service.yaml",
+          specification: ".spec.yaml",
+        },
         ...configOverrides,
       }),
       getInstance: jest.fn().mockReturnValue({
@@ -97,7 +110,10 @@ export function stubProjectConfigService(configOverrides: Record<string, any> = 
         loadWorkspaceConfig: jest.fn().mockResolvedValue(undefined),
         getAllConfigs: jest.fn().mockReturnValue([]),
         buildDefaultConfig: jest.fn().mockReturnValue({
-          extensions: { chain: ".qip-chain.yaml", service: ".qip-service.yaml" },
+          extensions: {
+            chain: ".qip-chain.yaml",
+            service: ".qip-service.yaml",
+          },
         }),
       }),
     },
@@ -105,11 +121,12 @@ export function stubProjectConfigService(configOverrides: Record<string, any> = 
   };
 }
 
-
 import type { IntegrationSystem } from "../../src/web/api-services/servicesTypes";
 import { IntegrationSystemType } from "../../src/web/api-services/servicesTypes";
 
-export function buildSystem(overrides: Partial<IntegrationSystem> = {}): IntegrationSystem {
+export function buildSystem(
+  overrides: Partial<IntegrationSystem> = {},
+): IntegrationSystem {
   return {
     id: "sys-1",
     name: "Test System",
@@ -123,7 +140,10 @@ export function buildSystem(overrides: Partial<IntegrationSystem> = {}): Integra
   };
 }
 
-export function buildServiceRecord(id: string, contentOverrides: Record<string, any> = {}) {
+export function buildServiceRecord(
+  id: string,
+  contentOverrides: Record<string, any> = {},
+) {
   return {
     id,
     content: { protocol: "HTTP", ...contentOverrides },

--- a/tests/response/serviceApiModify.test.ts
+++ b/tests/response/serviceApiModify.test.ts
@@ -1,0 +1,90 @@
+import {
+  createVscodeMock,
+  stubFileApi,
+  stubLabelUtils,
+  stubProjectConfigService,
+  buildServiceRecord,
+} from "../helpers/mocks";
+
+
+jest.mock("vscode", () => createVscodeMock(), { virtual: true });
+jest.mock("yaml", () => ({ stringify: jest.fn(), parse: jest.fn() }));
+jest.mock("../../src/web/response/file/fileApiProvider", () => stubFileApi());
+jest.mock("../../src/web/response/serviceApiRead", () => ({
+  getMainService: jest.fn(),
+  getService: jest.fn(),
+  getContextService: jest.fn(),
+}));
+jest.mock("../../src/web/response/file/fileExtensions", () => ({
+  getExtensionsForFile: jest.fn().mockReturnValue({ service: ".qip-service.yaml" }),
+  getExtensionsForUri: jest.fn().mockReturnValue({ service: ".qip-service.yaml" }),
+}));
+jest.mock("../../src/web/extension", () => ({ refreshQipExplorer: jest.fn() }));
+jest.mock("../../src/web/api-services/LabelUtils", () => stubLabelUtils());
+jest.mock("../../src/web/services/ProjectConfigService", () => stubProjectConfigService());
+jest.mock("../../src/web/api-services/parsers/ContentParser", () => ({
+  ContentParser: { parseContentFromFile: jest.fn() },
+}));
+jest.mock("@netcracker/qip-ui", () => ({}), { virtual: true });
+
+jest.mock("../../src/web/response/serviceApiUtils", () => {
+  const actual = jest.requireActual("../../src/web/response/serviceApiUtils");
+  return {
+    ...actual,
+    validateAllowedSystemProtocol: jest.fn(actual.validateAllowedSystemProtocol),
+  };
+});
+
+
+import { IntegrationSystemType, IntegrationSystem } from "../../src/web/api-services/servicesTypes";
+import { ApiSpecificationType } from "../../src/web/api-services/importApiTypes";
+import { updateService } from "../../src/web/response/serviceApiModify";
+import { getMainService, getService } from "../../src/web/response/serviceApiRead";
+import { validateAllowedSystemProtocol } from "../../src/web/response/serviceApiUtils";
+
+
+describe("updateService – validateAllowedSystemProtocol integration", () => {
+  const serviceFileUri = {} as any;
+  const serviceId = "svc-1";
+
+  beforeEach(() => jest.clearAllMocks());
+
+  test("calls validateAllowedSystemProtocol with (type, existing protocol) when type is set", async () => {
+    (getMainService as jest.Mock).mockResolvedValue(
+      buildServiceRecord(serviceId, { protocol: ApiSpecificationType.HTTP }),
+    );
+    (getService as jest.Mock).mockResolvedValue({ id: serviceId } as IntegrationSystem);
+
+    await updateService(serviceFileUri, serviceId, {
+      type: IntegrationSystemType.EXTERNAL,
+    } as Partial<IntegrationSystem>);
+
+    expect(validateAllowedSystemProtocol).toHaveBeenCalledWith(
+      IntegrationSystemType.EXTERNAL,
+      ApiSpecificationType.HTTP,
+    );
+  });
+
+  test("throws when type is IMPLEMENTED but stored protocol is GRPC", async () => {
+    (getMainService as jest.Mock).mockResolvedValue(
+      buildServiceRecord(serviceId, { protocol: ApiSpecificationType.GRPC }),
+    );
+
+    await expect(
+      updateService(serviceFileUri, serviceId, {
+        type: IntegrationSystemType.IMPLEMENTED,
+      } as Partial<IntegrationSystem>),
+    ).rejects.toThrow("Specification type is not allowed for implemented system: GRPC");
+  });
+
+  test("skips validation entirely when type is not provided", async () => {
+    (getMainService as jest.Mock).mockResolvedValue(buildServiceRecord(serviceId));
+    (getService as jest.Mock).mockResolvedValue({ id: serviceId } as IntegrationSystem);
+
+    await updateService(serviceFileUri, serviceId, {
+      name: "Updated Name",
+    } as Partial<IntegrationSystem>);
+
+    expect(validateAllowedSystemProtocol).not.toHaveBeenCalled();
+  });
+});

--- a/tests/response/serviceApiModify.test.ts
+++ b/tests/response/serviceApiModify.test.ts
@@ -6,7 +6,6 @@ import {
   buildServiceRecord,
 } from "../helpers/mocks";
 
-
 jest.mock("vscode", () => createVscodeMock(), { virtual: true });
 jest.mock("yaml", () => ({ stringify: jest.fn(), parse: jest.fn() }));
 jest.mock("../../src/web/response/file/fileApiProvider", () => stubFileApi());
@@ -16,12 +15,18 @@ jest.mock("../../src/web/response/serviceApiRead", () => ({
   getContextService: jest.fn(),
 }));
 jest.mock("../../src/web/response/file/fileExtensions", () => ({
-  getExtensionsForFile: jest.fn().mockReturnValue({ service: ".qip-service.yaml" }),
-  getExtensionsForUri: jest.fn().mockReturnValue({ service: ".qip-service.yaml" }),
+  getExtensionsForFile: jest
+    .fn()
+    .mockReturnValue({ service: ".qip-service.yaml" }),
+  getExtensionsForUri: jest
+    .fn()
+    .mockReturnValue({ service: ".qip-service.yaml" }),
 }));
 jest.mock("../../src/web/extension", () => ({ refreshQipExplorer: jest.fn() }));
 jest.mock("../../src/web/api-services/LabelUtils", () => stubLabelUtils());
-jest.mock("../../src/web/services/ProjectConfigService", () => stubProjectConfigService());
+jest.mock("../../src/web/services/ProjectConfigService", () =>
+  stubProjectConfigService(),
+);
 jest.mock("../../src/web/api-services/parsers/ContentParser", () => ({
   ContentParser: { parseContentFromFile: jest.fn() },
 }));
@@ -31,17 +36,23 @@ jest.mock("../../src/web/response/serviceApiUtils", () => {
   const actual = jest.requireActual("../../src/web/response/serviceApiUtils");
   return {
     ...actual,
-    validateAllowedSystemProtocol: jest.fn(actual.validateAllowedSystemProtocol),
+    validateAllowedSystemProtocol: jest.fn(
+      actual.validateAllowedSystemProtocol,
+    ),
   };
 });
 
-
-import { IntegrationSystemType, IntegrationSystem } from "../../src/web/api-services/servicesTypes";
+import {
+  IntegrationSystemType,
+  IntegrationSystem,
+} from "../../src/web/api-services/servicesTypes";
 import { ApiSpecificationType } from "../../src/web/api-services/importApiTypes";
 import { updateService } from "../../src/web/response/serviceApiModify";
-import { getMainService, getService } from "../../src/web/response/serviceApiRead";
+import {
+  getMainService,
+  getService,
+} from "../../src/web/response/serviceApiRead";
 import { validateAllowedSystemProtocol } from "../../src/web/response/serviceApiUtils";
-
 
 describe("updateService – validateAllowedSystemProtocol integration", () => {
   const serviceFileUri = {} as any;
@@ -53,7 +64,9 @@ describe("updateService – validateAllowedSystemProtocol integration", () => {
     (getMainService as jest.Mock).mockResolvedValue(
       buildServiceRecord(serviceId, { protocol: ApiSpecificationType.HTTP }),
     );
-    (getService as jest.Mock).mockResolvedValue({ id: serviceId } as IntegrationSystem);
+    (getService as jest.Mock).mockResolvedValue({
+      id: serviceId,
+    } as IntegrationSystem);
 
     await updateService(serviceFileUri, serviceId, {
       type: IntegrationSystemType.EXTERNAL,
@@ -74,12 +87,18 @@ describe("updateService – validateAllowedSystemProtocol integration", () => {
       updateService(serviceFileUri, serviceId, {
         type: IntegrationSystemType.IMPLEMENTED,
       } as Partial<IntegrationSystem>),
-    ).rejects.toThrow("Specification type is not allowed for implemented system: GRPC");
+    ).rejects.toThrow(
+      "Specification type is not allowed for implemented system: GRPC",
+    );
   });
 
   test("skips validation entirely when type is not provided", async () => {
-    (getMainService as jest.Mock).mockResolvedValue(buildServiceRecord(serviceId));
-    (getService as jest.Mock).mockResolvedValue({ id: serviceId } as IntegrationSystem);
+    (getMainService as jest.Mock).mockResolvedValue(
+      buildServiceRecord(serviceId),
+    );
+    (getService as jest.Mock).mockResolvedValue({
+      id: serviceId,
+    } as IntegrationSystem);
 
     await updateService(serviceFileUri, serviceId, {
       name: "Updated Name",

--- a/tests/response/serviceApiUtils.test.ts
+++ b/tests/response/serviceApiUtils.test.ts
@@ -1,0 +1,81 @@
+import { createMinimalVscodeMock } from "../helpers/mocks";
+
+jest.mock("vscode", () => createMinimalVscodeMock(), { virtual: true });
+jest.mock("../../src/web/response/file/fileApiProvider", () => ({ fileApi: {} }));
+jest.mock("../../src/web/response/serviceApiRead", () => ({ getCurrentServiceId: jest.fn() }));
+jest.mock("../../src/web/response/serviceApiModify", () => ({ createService: jest.fn() }));
+jest.mock("../../src/web/api-services/SpecificationImportApiHandler", () => ({
+  SpecificationImportApiHandler: jest.fn(),
+}));
+
+import { ApiSpecificationType } from "../../src/web/api-services/importApiTypes";
+import { IntegrationSystemType } from "../../src/web/api-services/servicesTypes";
+import {
+  ALLOWED_PROTOCOL_MAP,
+  validateAllowedSystemProtocol,
+} from "../../src/web/response/serviceApiUtils";
+
+describe("ALLOWED_PROTOCOL_MAP", () => {
+  const allProtocols = Object.values(ApiSpecificationType);
+
+  test.each([
+    ["EXTERNAL", IntegrationSystemType.EXTERNAL],
+    ["INTERNAL", IntegrationSystemType.INTERNAL],
+  ])("%s allows all protocol types", (_label, systemType) => {
+    const allowed = ALLOWED_PROTOCOL_MAP.get(systemType);
+    expect(allowed).toBeDefined();
+    for (const protocol of allProtocols) {
+      expect(allowed!.has(protocol)).toBe(true);
+    }
+  });
+
+  test("IMPLEMENTED allows only HTTP, SOAP, GRAPHQL", () => {
+    const allowed = ALLOWED_PROTOCOL_MAP.get(IntegrationSystemType.IMPLEMENTED)!;
+    expect(allowed).toBeDefined();
+
+    const expectedAllowed = [ApiSpecificationType.HTTP, ApiSpecificationType.SOAP, ApiSpecificationType.GRAPHQL];
+    const expectedBlocked = [ApiSpecificationType.GRPC, ApiSpecificationType.KAFKA, ApiSpecificationType.AMQP];
+
+    expectedAllowed.forEach((p) => expect(allowed.has(p)).toBe(true));
+    expectedBlocked.forEach((p) => expect(allowed.has(p)).toBe(false));
+  });
+
+  test("does not contain CONTEXT system type", () => {
+    expect(ALLOWED_PROTOCOL_MAP.has(IntegrationSystemType.CONTEXT)).toBe(false);
+  });
+});
+
+describe("validateAllowedSystemProtocol", () => {
+  describe("returns silently when systemType or protocol is missing", () => {
+    test.each([
+      ["systemType is undefined", undefined, ApiSpecificationType.HTTP],
+      ["protocol is undefined", IntegrationSystemType.EXTERNAL, undefined],
+      ["both are undefined", undefined, undefined],
+    ])("%s", (_label, systemType, protocol) => {
+      expect(() => validateAllowedSystemProtocol(systemType, protocol)).not.toThrow();
+    });
+  });
+
+  describe("does not throw for allowed combinations", () => {
+    test.each([
+      ["EXTERNAL + HTTP", IntegrationSystemType.EXTERNAL, ApiSpecificationType.HTTP],
+      ["INTERNAL + KAFKA", IntegrationSystemType.INTERNAL, ApiSpecificationType.KAFKA],
+      ["IMPLEMENTED + SOAP", IntegrationSystemType.IMPLEMENTED, ApiSpecificationType.SOAP],
+      ["CONTEXT (not in map) + HTTP", IntegrationSystemType.CONTEXT, ApiSpecificationType.HTTP],
+    ])("%s", (_label, systemType, protocol) => {
+      expect(() => validateAllowedSystemProtocol(systemType, protocol)).not.toThrow();
+    });
+  });
+
+  describe("throws for disallowed combinations", () => {
+    test.each([
+      [ApiSpecificationType.GRPC],
+      [ApiSpecificationType.KAFKA],
+      [ApiSpecificationType.AMQP],
+    ])("IMPLEMENTED + %s", (protocol) => {
+      expect(() =>
+        validateAllowedSystemProtocol(IntegrationSystemType.IMPLEMENTED, protocol),
+      ).toThrow(`Specification type is not allowed for implemented system: ${protocol}`);
+    });
+  });
+});

--- a/tests/response/serviceApiUtils.test.ts
+++ b/tests/response/serviceApiUtils.test.ts
@@ -1,9 +1,15 @@
 import { createMinimalVscodeMock } from "../helpers/mocks";
 
 jest.mock("vscode", () => createMinimalVscodeMock(), { virtual: true });
-jest.mock("../../src/web/response/file/fileApiProvider", () => ({ fileApi: {} }));
-jest.mock("../../src/web/response/serviceApiRead", () => ({ getCurrentServiceId: jest.fn() }));
-jest.mock("../../src/web/response/serviceApiModify", () => ({ createService: jest.fn() }));
+jest.mock("../../src/web/response/file/fileApiProvider", () => ({
+  fileApi: {},
+}));
+jest.mock("../../src/web/response/serviceApiRead", () => ({
+  getCurrentServiceId: jest.fn(),
+}));
+jest.mock("../../src/web/response/serviceApiModify", () => ({
+  createService: jest.fn(),
+}));
 jest.mock("../../src/web/api-services/SpecificationImportApiHandler", () => ({
   SpecificationImportApiHandler: jest.fn(),
 }));
@@ -30,11 +36,21 @@ describe("ALLOWED_PROTOCOL_MAP", () => {
   });
 
   test("IMPLEMENTED allows only HTTP, SOAP, GRAPHQL", () => {
-    const allowed = ALLOWED_PROTOCOL_MAP.get(IntegrationSystemType.IMPLEMENTED)!;
+    const allowed = ALLOWED_PROTOCOL_MAP.get(
+      IntegrationSystemType.IMPLEMENTED,
+    )!;
     expect(allowed).toBeDefined();
 
-    const expectedAllowed = [ApiSpecificationType.HTTP, ApiSpecificationType.SOAP, ApiSpecificationType.GRAPHQL];
-    const expectedBlocked = [ApiSpecificationType.GRPC, ApiSpecificationType.KAFKA, ApiSpecificationType.AMQP];
+    const expectedAllowed = [
+      ApiSpecificationType.HTTP,
+      ApiSpecificationType.SOAP,
+      ApiSpecificationType.GRAPHQL,
+    ];
+    const expectedBlocked = [
+      ApiSpecificationType.GRPC,
+      ApiSpecificationType.KAFKA,
+      ApiSpecificationType.AMQP,
+    ];
 
     expectedAllowed.forEach((p) => expect(allowed.has(p)).toBe(true));
     expectedBlocked.forEach((p) => expect(allowed.has(p)).toBe(false));
@@ -52,18 +68,38 @@ describe("validateAllowedSystemProtocol", () => {
       ["protocol is undefined", IntegrationSystemType.EXTERNAL, undefined],
       ["both are undefined", undefined, undefined],
     ])("%s", (_label, systemType, protocol) => {
-      expect(() => validateAllowedSystemProtocol(systemType, protocol)).not.toThrow();
+      expect(() =>
+        validateAllowedSystemProtocol(systemType, protocol),
+      ).not.toThrow();
     });
   });
 
   describe("does not throw for allowed combinations", () => {
     test.each([
-      ["EXTERNAL + HTTP", IntegrationSystemType.EXTERNAL, ApiSpecificationType.HTTP],
-      ["INTERNAL + KAFKA", IntegrationSystemType.INTERNAL, ApiSpecificationType.KAFKA],
-      ["IMPLEMENTED + SOAP", IntegrationSystemType.IMPLEMENTED, ApiSpecificationType.SOAP],
-      ["CONTEXT (not in map) + HTTP", IntegrationSystemType.CONTEXT, ApiSpecificationType.HTTP],
+      [
+        "EXTERNAL + HTTP",
+        IntegrationSystemType.EXTERNAL,
+        ApiSpecificationType.HTTP,
+      ],
+      [
+        "INTERNAL + KAFKA",
+        IntegrationSystemType.INTERNAL,
+        ApiSpecificationType.KAFKA,
+      ],
+      [
+        "IMPLEMENTED + SOAP",
+        IntegrationSystemType.IMPLEMENTED,
+        ApiSpecificationType.SOAP,
+      ],
+      [
+        "CONTEXT (not in map) + HTTP",
+        IntegrationSystemType.CONTEXT,
+        ApiSpecificationType.HTTP,
+      ],
     ])("%s", (_label, systemType, protocol) => {
-      expect(() => validateAllowedSystemProtocol(systemType, protocol)).not.toThrow();
+      expect(() =>
+        validateAllowedSystemProtocol(systemType, protocol),
+      ).not.toThrow();
     });
   });
 
@@ -74,8 +110,13 @@ describe("validateAllowedSystemProtocol", () => {
       [ApiSpecificationType.AMQP],
     ])("IMPLEMENTED + %s", (protocol) => {
       expect(() =>
-        validateAllowedSystemProtocol(IntegrationSystemType.IMPLEMENTED, protocol),
-      ).toThrow(`Specification type is not allowed for implemented system: ${protocol}`);
+        validateAllowedSystemProtocol(
+          IntegrationSystemType.IMPLEMENTED,
+          protocol,
+        ),
+      ).toThrow(
+        `Specification type is not allowed for implemented system: ${protocol}`,
+      );
     });
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,10 +5,7 @@
     "declaration": true,
     "target": "ES2020",
     "outDir": "dist",
-    "lib": [
-      "ES2020",
-      "WebWorker"
-    ],
+    "lib": ["ES2020", "WebWorker"],
     "sourceMap": true,
     "rootDir": "src",
     "strict": true,
@@ -22,5 +19,7 @@
         "./node_modules/@netcracker/qip-ui/node_modules/@netcracker/qip-schemas/*"
       ]
     }
-  }
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "tests"]
 }


### PR DESCRIPTION
The check for protocol was added in:
1. During API Specification import into service
2. Selecting service type 

Also linter was applied to extension.ts and change error messaging for correct format